### PR TITLE
Update Server Openstack Interface

### DIFF
--- a/charts/unikorn/templates/unikorn-server.yaml
+++ b/charts/unikorn/templates/unikorn-server.yaml
@@ -107,6 +107,37 @@ spec:
           {{ printf "- --oidc-issuer-ca=%s" $oidc.issuerCA | nindent 8 }}
           {{- end }}
         {{- end }}
+        {{- with $openstack := .Values.server.provider.openstack }}
+          {{ printf "- --openstack-endpoint=%s" $openstack.endpoint | nindent 8 }}
+          {{- with $secret := $openstack.serviceAccount.secret }}
+            {{ printf "- --openstack-serviceaccount-secret=%s" $secret.name | nindent 8 }}
+          {{- end }}
+          {{- with $identity := $openstack.identity }}
+            {{- range $roles := $identity.applicationCredentialRoles }}
+              {{ printf "- --openstack-identity-application-credential-roles=%s" (join "," $roles) | nindent 8 }}
+            {{- end }}
+          {{- end }}
+          {{- with $compute := $openstack.compute }}
+            {{- with $policy := $compute.serverGroupPolicy }}
+              {{ printf "- --openstack-servergroup-policy=%s" $policy | nindent 8 }}
+            {{- end }}
+            {{- with $props := $compute.flavorPropertiesExclude }}
+              {{ printf "- --openstack-flavor-properties-exclude=%s" (join "," $props) | nindent 8 }}
+            {{- end }}
+            {{- range $desc := $compute.flavorGpuDescriptors }}
+              {{ printf "- --openstack-flavor-gpu-descriptor=property=%s,expression=%s" $desc.property $desc.expression | nindent 8 }}
+            {{- end }}
+          {{- end }}
+          {{- with $image := $openstack.image }}
+            {{ with $props := $image.properties }}
+              {{ printf "- --openstack-image-properties=%s" (join "," $props) | nindent 8 }}
+            {{- end }}
+            {{- with $key := $image.signingKey }}
+              {{ printf "- --openstack-image-signing-key=%s" $key | nindent 8 }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+
         {{- if .Values.server.imageSigningKey }}
         - --image-signing-key={{ .Values.server.imageSigningKey }}
         {{- end }}

--- a/charts/unikorn/values.yaml
+++ b/charts/unikorn/values.yaml
@@ -47,6 +47,73 @@ server:
   # Allows override of the global default image.
   image:
 
+  # Define the cloud provider credentials.
+  provider:
+    # OpenStack is an open-source cloud solution, allowing on-premise
+    # deployments of public or private clouds.
+    openstack:
+      # The Keystone service endpoint.
+      endpoint: https://openstack.acme.com
+
+      # Defines the service account credentials.  Unikorn uses federated
+      # identity via OIDC, and while OpenStack can be configured to do so
+      # we use application credentials to allow clusters to self manage.
+      # OpenStack does not allow federated application credentials because
+      # it cannot know when a user is revoked and propagate this to an
+      # application credential.
+      serviceAccount:
+        # The secret must exist in the same namespace as Unikorn, and contain
+        # the key applicationcredentialid (as this is globally unique) and secret.
+        # This must be a full admin account in order to provision projects and
+        # other RBAC related items, and be unrestricted so it can create other
+        # application credentials for individual clusters under management.
+        secret:
+          name: openstack-applicationcredential
+
+      identity:
+        # Define the roles that are required for Cluster API to function
+        # correctly, typically this will include compute, networking and
+        # LBaaS.
+        applicationCredentialRoles:
+        - member
+        - load-balancer_member
+
+      compute:
+        # Unikorn uses OpenStack anti-affinity rules to provision Kubernetes
+        # control plane nodes as Cluster API is awful and yields broken clusters.
+        serverGroupPolicy: soft-anti-affinity
+
+        # # Allows filtering of flavors with defined properties.
+        # flavorPropertiesExclude:
+        # - resources:CUSTOM_BAREMETAL
+
+        # Allows GPU metadata to be extracted from the flavor extra specs.
+        # If the property exists, then apply the expression to extract the number
+        # of GPUs.
+        flavorGpuDescriptors:
+        - property: resources:PGPU
+          expression: ^(\d+)$
+        - property: resources:VGPU
+          expression: ^(\d+)$
+
+      # image:
+      #   # If defined this will filter compute images based on whether all the
+      #   # given properies exist on an image.  One particular use that is hightly
+      #   # recommended is to use the property "k8s" that defines the preinstalled
+      #   # version of Kubernetes to improve cluster provisioning time.
+      #   # properties:
+      #   - k8s
+      #
+      #   # If defined this will filter compute images based on whether or not
+      #   # the image is signed by an external authority.  This is userful on
+      #   # multi tenant clouds where other non-unikorn images may exist.
+      #   # Signatures are attached to an image via the "digest" metadata property
+      #   # and the value is a base64 encoded ECDSA hash over the image ID, that
+      #   # cannot be manually overriden by a user in order to resuse an existing
+      #   # signature.  Public key types other that eliptic curve are not currently
+      #   # supported.
+      #   signingKey: ~
+
   ingress:
     # Sets the ingress class to use.
     ingressClass: nginx

--- a/pkg/flags/publickey.go
+++ b/pkg/flags/publickey.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2024 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrPEMDecode is raised when the PEM decode failed for some reason.
+	ErrPEMDecode = errors.New("PEM decode error")
+
+	// ErrPEMType is raised when the encounter the wrong PEM type, e.g. PKCS#1.
+	ErrPEMType = errors.New("PEM type unsupported")
+
+	// ErrKeyType is raised when we encounter an unsupported key type.
+	ErrKeyType = errors.New("key type unsupported")
+)
+
+// PublicKeyVar contains a public key.
+type PublicKeyVar struct {
+	Key *ecdsa.PublicKey
+}
+
+// Set accepts a base64 encoded PEM public key and tries to decode it.
+func (v *PublicKeyVar) Set(s string) error {
+	if s == "" {
+		return nil
+	}
+
+	pemString, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return err
+	}
+
+	pemBlock, _ := pem.Decode(pemString)
+	if pemBlock == nil {
+		return ErrPEMDecode
+	}
+
+	if pemBlock.Type != "PUBLIC KEY" {
+		return fmt.Errorf("%w: %s", ErrPEMType, pemBlock.Type)
+	}
+
+	key, err := x509.ParsePKIXPublicKey(pemBlock.Bytes)
+	if err != nil {
+		return err
+	}
+
+	ecKey, ok := key.(*ecdsa.PublicKey)
+	if !ok {
+		return ErrKeyType
+	}
+
+	v.Key = ecKey
+
+	return nil
+}
+
+func (v *PublicKeyVar) String() string {
+	return ""
+}
+
+func (v *PublicKeyVar) Type() string {
+	return "publickey"
+}

--- a/pkg/providers/openstack/image.go
+++ b/pkg/providers/openstack/image.go
@@ -26,21 +26,35 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
+	"github.com/spf13/pflag"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/exp/slices"
 
 	"github.com/unikorn-cloud/core/pkg/constants"
 	"github.com/unikorn-cloud/core/pkg/util"
+	"github.com/unikorn-cloud/unikorn/pkg/flags"
 )
+
+// ImageOptions allows things like filtering to be configured.
+type ImageOptions struct {
+	Properties []string
+	SigningKey flags.PublicKeyVar
+}
+
+func (o *ImageOptions) AddFlags(f *pflag.FlagSet) {
+	f.StringSliceVar(&o.Properties, "openstack-image-properties", nil, "Properties an image must possess in order to be exposed")
+	f.Var(&o.SigningKey, "openstack-image-signing-key", "Public key used to verify valid images for use with the platform")
+}
 
 // ImageClient wraps the generic client because gophercloud is unsafe.
 type ImageClient struct {
-	client *gophercloud.ServiceClient
+	client  *gophercloud.ServiceClient
+	options *ImageOptions
 }
 
 // NewImageClient provides a simple one-liner to start computing.
-func NewImageClient(provider Provider) (*ImageClient, error) {
+func NewImageClient(provider Provider, options *ImageOptions) (*ImageClient, error) {
 	providerClient, err := provider.Client()
 	if err != nil {
 		return nil, err
@@ -52,14 +66,15 @@ func NewImageClient(provider Provider) (*ImageClient, error) {
 	}
 
 	c := &ImageClient{
-		client: client,
+		client:  client,
+		options: options,
 	}
 
 	return c, nil
 }
 
-func validateProperties(image *images.Image, required []string) bool {
-	for _, r := range required {
+func (c *ImageClient) validateProperties(image *images.Image) bool {
+	for _, r := range c.options.Properties {
 		if !slices.Contains(util.Keys(image.Properties), r) {
 			return false
 		}
@@ -69,12 +84,12 @@ func validateProperties(image *images.Image, required []string) bool {
 }
 
 // verifyImage asserts the image is trustworthy for use with our goodselves.
-func verifyImage(image *images.Image, key *ecdsa.PublicKey) bool {
+func (c *ImageClient) verifyImage(image *images.Image) bool {
 	if image.Properties == nil {
 		return false
 	}
 
-	if key != nil {
+	if c.options.SigningKey.Key != nil {
 		// These will be digitally signed by Baski when created, so we only trust
 		// those images.
 		signatureRaw, ok := image.Properties["digest"]
@@ -94,14 +109,14 @@ func verifyImage(image *images.Image, key *ecdsa.PublicKey) bool {
 
 		hash := sha256.Sum256([]byte(image.ID))
 
-		return ecdsa.VerifyASN1(key, hash[:], signature)
+		return ecdsa.VerifyASN1(c.options.SigningKey.Key, hash[:], signature)
 	}
 
 	return true
 }
 
 // Images returns a list of images.
-func (c *ImageClient) Images(ctx context.Context, key *ecdsa.PublicKey, properties []string) ([]images.Image, error) {
+func (c *ImageClient) Images(ctx context.Context) ([]images.Image, error) {
 	tracer := otel.GetTracerProvider().Tracer(constants.Application)
 
 	_, span := tracer.Start(ctx, "/imageservice/v2/images", trace.WithSpanKind(trace.SpanKindClient))
@@ -127,13 +142,11 @@ func (c *ImageClient) Images(ctx context.Context, key *ecdsa.PublicKey, properti
 			continue
 		}
 
-		if properties != nil {
-			if !validateProperties(&image, properties) {
-				continue
-			}
+		if !c.validateProperties(&image) {
+			continue
 		}
 
-		if !verifyImage(&image, key) {
+		if !c.verifyImage(&image) {
 			continue
 		}
 

--- a/pkg/server/handler/providers/openstack/openstack.go
+++ b/pkg/server/handler/providers/openstack/openstack.go
@@ -241,7 +241,7 @@ func (o *Openstack) ImageClient(r *http.Request) (*openstack.ImageClient, error)
 		return client, nil
 	}
 
-	client, err := openstack.NewImageClient(openstack.NewTokenProvider(o.endpoint, token))
+	client, err := openstack.NewImageClient(openstack.NewTokenProvider(o.endpoint, token), &o.options.ImageOptions)
 	if err != nil {
 		return nil, errors.OAuth2ServerError("failed get image client").WithError(err)
 	}
@@ -443,7 +443,7 @@ func (o *Openstack) ListImages(r *http.Request) (generated.OpenstackImages, erro
 		return nil, errors.OAuth2ServerError("failed get image client").WithError(err)
 	}
 
-	result, err := client.Images(r.Context(), o.options.Key.key, o.options.Properties)
+	result, err := client.Images(r.Context())
 	if err != nil {
 		return nil, covertError(err)
 	}
@@ -660,7 +660,7 @@ func (o *Openstack) CreateServerGroup(r *http.Request, name string) (*servergrou
 		return nil, errors.OAuth2ServerError("failed get compute client").WithError(err)
 	}
 
-	result, err := client.CreateServerGroup(r.Context(), name, o.options.ServerGroupPolicy)
+	result, err := client.CreateServerGroup(r.Context(), name)
 	if err != nil {
 		return nil, covertError(err)
 	}

--- a/pkg/server/handler/providers/openstack/options.go
+++ b/pkg/server/handler/providers/openstack/options.go
@@ -18,91 +18,33 @@ limitations under the License.
 package openstack
 
 import (
-	"crypto/ecdsa"
-	"crypto/x509"
-	"encoding/base64"
-	"encoding/pem"
-	"errors"
-	"fmt"
-
 	"github.com/spf13/pflag"
 
 	"github.com/unikorn-cloud/unikorn/pkg/providers/openstack"
 )
 
-var (
-	// ErrPEMDecode is raised when the PEM decode failed for some reason.
-	ErrPEMDecode = errors.New("PEM decode error")
-
-	// ErrPEMType is raised when the encounter the wrong PEM type, e.g. PKCS#1.
-	ErrPEMType = errors.New("PEM type unsupported")
-
-	// ErrKeyType is raised when we encounter an unsupported key type.
-	ErrKeyType = errors.New("key type unsupported")
-)
-
-// PublicKeyVar contains a public key.
-type PublicKeyVar struct {
-	key *ecdsa.PublicKey
-}
-
-// Set accepts a base64 encoded PEM public key and tries to decode it.
-func (v *PublicKeyVar) Set(s string) error {
-	if s == "" {
-		return nil
-	}
-
-	pemString, err := base64.StdEncoding.DecodeString(s)
-	if err != nil {
-		return err
-	}
-
-	pemBlock, _ := pem.Decode(pemString)
-	if pemBlock == nil {
-		return ErrPEMDecode
-	}
-
-	if pemBlock.Type != "PUBLIC KEY" {
-		return fmt.Errorf("%w: %s", ErrPEMType, pemBlock.Type)
-	}
-
-	key, err := x509.ParsePKIXPublicKey(pemBlock.Bytes)
-	if err != nil {
-		return err
-	}
-
-	ecKey, ok := key.(*ecdsa.PublicKey)
-	if !ok {
-		return ErrKeyType
-	}
-
-	v.key = ecKey
-
-	return nil
-}
-
-func (v *PublicKeyVar) String() string {
-	return ""
-}
-
-func (v *PublicKeyVar) Type() string {
-	return "publickey"
-}
-
 type Options struct {
-	ComputeOptions    openstack.ComputeOptions
-	Key               PublicKeyVar
-	ServerGroupPolicy string
-	Properties        []string
-	// applicationCredentialRoles sets the roles an application credential
+	// Endpoint is the Keystone/discovery endpoint.
+	Endpoint string
+
+	// ServiceAccountSecret is the secret that we get our credentials from.
+	// By design, this should be read each time to facilitate credential
+	// rotation.
+	ServiceAccountSecret string
+
+	// ApplicationCredentialRoles sets the roles an application credential
 	// is granted on creation.
 	ApplicationCredentialRoles []string
+
+	ComputeOptions openstack.ComputeOptions
+	ImageOptions   openstack.ImageOptions
 }
 
 func (o *Options) AddFlags(f *pflag.FlagSet) {
+	f.StringVar(&o.Endpoint, "openstack-endpoint", "https://keystone.openstack.org:5000", "Openstack discovery endpoint")
+	f.StringVar(&o.ServiceAccountSecret, "openstack-serviceaccount-secret", "", "Secret containing a 'seviceaccountid' key")
+	f.StringSliceVar(&o.ApplicationCredentialRoles, "openstack-identity-application-credential-roles", nil, "A role to be added to application credentials on creation.  May be specified more than once.")
+
 	o.ComputeOptions.AddFlags(f)
-	f.Var(&o.Key, "image-signing-key", "Key used to verify valid images for use with the platform")
-	f.StringSliceVar(&o.Properties, "image-properties", nil, "Properties used to filter the list of images")
-	f.StringVar(&o.ServerGroupPolicy, "server-group-policy", "soft-anti-affinity", "Scheduling policy to use for server groups")
-	f.StringSliceVar(&o.ApplicationCredentialRoles, "application-credential-roles", nil, "A role to be added to application credentials on creation.  May be specified more than once.")
+	o.ImageOptions.AddFlags(f)
 }


### PR DESCRIPTION
We are moving away from OpenStack being the only provider, so make it so the helm/CLI interfaces are unambiguous and properly scoped.  Refactor flags so they live closer to where they will be used to stop abuse.  Add in half of the support for unikorn application credentials, rest will come next week!