### PR TITLE
Return Empty Lists

### DIFF
--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: v0.1.10
-appVersion: v0.1.10
+version: v0.1.11
+appVersion: v0.1.11
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/unikorn/main/icons/default.png

--- a/pkg/server/handler/cluster/client.go
+++ b/pkg/server/handler/cluster/client.go
@@ -83,13 +83,17 @@ func NewClient(client client.Client, options *Options) *Client {
 }
 
 // List returns all clusters owned by the implicit control plane.
-func (c *Client) List(ctx context.Context, organizationName string) ([]*generated.KubernetesCluster, error) {
+func (c *Client) List(ctx context.Context, organizationName string) (generated.KubernetesClusters, error) {
 	selector := labels.NewSelector()
 
 	// TODO: a super-admin isn't scoped to a single organization!
 	// TODO: RBAC - filter projects based on user membership here.
 	organization, err := organization.NewClient(c.client).GetMetadata(ctx, organizationName)
 	if err != nil {
+		if errors.IsHTTPNotFound(err) {
+			return generated.KubernetesClusters{}, nil
+		}
+
 		return nil, err
 	}
 

--- a/pkg/server/handler/cluster/conversion.go
+++ b/pkg/server/handler/cluster/conversion.go
@@ -137,8 +137,8 @@ func (c *Client) convert(in *unikornv1.KubernetesCluster) (*generated.Kubernetes
 }
 
 // uconvertList converts from a custom resource list into the API definition.
-func (c *Client) convertList(in *unikornv1.KubernetesClusterList) ([]*generated.KubernetesCluster, error) {
-	out := make([]*generated.KubernetesCluster, len(in.Items))
+func (c *Client) convertList(in *unikornv1.KubernetesClusterList) (generated.KubernetesClusters, error) {
+	out := make(generated.KubernetesClusters, len(in.Items))
 
 	for i := range in.Items {
 		item, err := c.convert(&in.Items[i])
@@ -146,7 +146,7 @@ func (c *Client) convertList(in *unikornv1.KubernetesClusterList) ([]*generated.
 			return nil, err
 		}
 
-		out[i] = item
+		out[i] = *item
 	}
 
 	return out, nil


### PR DESCRIPTION
When an acestor doesn't exist, e.g. the organization hasn't been created yet by project creation.  Makes UI handling far simpler.