### PR TITLE
Raise Events on Cluster Deletion

### DIFF
--- a/charts/unikorn/templates/unikorn-cluster-controller.yaml
+++ b/charts/unikorn/templates/unikorn-cluster-controller.yaml
@@ -80,6 +80,14 @@ rules:
   - create
   - patch
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.19.0
 	github.com/spdx/tools-golang v0.5.3
 	github.com/spf13/pflag v1.0.5
-	github.com/unikorn-cloud/core v0.1.23
+	github.com/unikorn-cloud/core v0.1.24
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.24.0
 	go.opentelemetry.io/otel/sdk v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v0.1.23 h1:8Wf8IjG3RSrY+TwDov0zJb8qo7AsW00cLjpmnNUnjFY=
-github.com/unikorn-cloud/core v0.1.23/go.mod h1:cP39UQN7aSmsfjQuSMsworI4oBIwx4oA4u20CbPpfZw=
+github.com/unikorn-cloud/core v0.1.24 h1:jN0CGLYiFy5fQJghqi3frKJVxoMoq+Weqc2PJNRsPAk=
+github.com/unikorn-cloud/core v0.1.24/go.mod h1:cP39UQN7aSmsfjQuSMsworI4oBIwx4oA4u20CbPpfZw=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=

--- a/pkg/managers/cluster/manager.go
+++ b/pkg/managers/cluster/manager.go
@@ -46,7 +46,7 @@ func (*Factory) Metadata() (string, string, string) {
 
 // Reconciler returns a new reconciler instance.
 func (*Factory) Reconciler(options *options.Options, manager manager.Manager) reconcile.Reconciler {
-	return coremanager.NewReconciler(options, manager.GetClient(), cluster.New)
+	return coremanager.NewReconciler(options, manager, cluster.New)
 }
 
 // RegisterWatches adds any watches that would trigger a reconcile.

--- a/pkg/managers/clustermanager/manager.go
+++ b/pkg/managers/clustermanager/manager.go
@@ -46,7 +46,7 @@ func (*Factory) Metadata() (string, string, string) {
 
 // Reconciler returns a new reconciler instance.
 func (*Factory) Reconciler(options *options.Options, manager manager.Manager) reconcile.Reconciler {
-	return coremanager.NewReconciler(options, manager.GetClient(), clustermanager.New)
+	return coremanager.NewReconciler(options, manager, clustermanager.New)
 }
 
 // RegisterWatches adds any watches that would trigger a reconcile.

--- a/pkg/providers/constants.go
+++ b/pkg/providers/constants.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2024 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"maps"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	MetdataDomain = "provider.unikorn-cloud.org"
+)
+
+func GetAnnotations(resource metav1.Object) map[string]string {
+	annotations := maps.Clone(resource.GetAnnotations())
+
+	maps.DeleteFunc(annotations, func(k, v string) bool {
+		return !strings.Contains(k, MetdataDomain)
+	})
+
+	return annotations
+}

--- a/pkg/providers/openstack/provider.go
+++ b/pkg/providers/openstack/provider.go
@@ -306,7 +306,7 @@ func (p *Provider) Images(ctx context.Context) (providers.ImageList, error) {
 
 const (
 	// ProjectIDAnnotation records the project ID created for a cluster.
-	ProjectIDAnnotation = "openstack.unikorn-cloud.org/project-id"
+	ProjectIDAnnotation = "openstack." + providers.MetdataDomain + "/project-id"
 
 	// Projects are randomly named to avoid clashes, so we need to add some tags
 	// in order to be able to reason about who they really belong to.  It is also
@@ -315,7 +315,6 @@ const (
 	OrganizationTag = "organization"
 	ProjectTag      = "project"
 	ClusterTag      = "cluster"
-	ClusterUUIDTag  = "clusterUUID"
 )
 
 // projectTags defines how to tag projects.

--- a/pkg/provisioners/managers/cluster/provisioner.go
+++ b/pkg/provisioners/managers/cluster/provisioner.go
@@ -25,6 +25,7 @@ import (
 	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	coreclient "github.com/unikorn-cloud/core/pkg/client"
 	"github.com/unikorn-cloud/core/pkg/constants"
+	"github.com/unikorn-cloud/core/pkg/manager"
 	"github.com/unikorn-cloud/core/pkg/provisioners"
 	"github.com/unikorn-cloud/core/pkg/provisioners/concurrent"
 	"github.com/unikorn-cloud/core/pkg/provisioners/conditional"
@@ -33,6 +34,7 @@ import (
 	provisionersutil "github.com/unikorn-cloud/core/pkg/provisioners/util"
 	"github.com/unikorn-cloud/core/pkg/util"
 	unikornv1 "github.com/unikorn-cloud/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/unikorn/pkg/providers"
 	"github.com/unikorn-cloud/unikorn/pkg/provisioners/helmapplications/cilium"
 	"github.com/unikorn-cloud/unikorn/pkg/provisioners/helmapplications/clusterautoscaler"
 	"github.com/unikorn-cloud/unikorn/pkg/provisioners/helmapplications/clusterautoscaleropenstack"
@@ -245,6 +247,10 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 	if err := provisioner.Deprovision(ctx); err != nil {
 		return err
 	}
+
+	// This event is used to trigger cleanup operations in the provider.
+	recorder := manager.FromContext(ctx).GetEventRecorderFor("cluster")
+	recorder.AnnotatedEventf(&p.cluster, providers.GetAnnotations(&p.cluster), "Normal", "ClusterDeleted", "cluster has been deleted successfully")
 
 	return nil
 }


### PR DESCRIPTION
We can capture these in monitor and do clean up actions e.g. delete projects, provider networks etc.