### PR TITLE
Add in a Infrastructure Reaper

### DIFF
--- a/charts/unikorn/templates/unikorn-server.yaml
+++ b/charts/unikorn/templates/unikorn-server.yaml
@@ -58,6 +58,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cmd/unikorn-server/main.go
+++ b/cmd/unikorn-server/main.go
@@ -33,6 +33,7 @@ import (
 	unikornv1 "github.com/unikorn-cloud/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/unikorn/pkg/constants"
 	"github.com/unikorn-cloud/unikorn/pkg/server"
+	"github.com/unikorn-cloud/unikorn/pkg/server/reaper"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -73,6 +74,12 @@ func start() {
 	server, err := s.GetServer(client)
 	if err != nil {
 		logger.Error(err, "failed to setup Handler")
+
+		return
+	}
+
+	if err := reaper.New(client).Run(ctx); err != nil {
+		logger.Error(err, "failed to setup 'The Reaper'")
 
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.19.0
 	github.com/spdx/tools-golang v0.5.3
 	github.com/spf13/pflag v1.0.5
-	github.com/unikorn-cloud/core v0.1.24
+	github.com/unikorn-cloud/core v0.1.26
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.24.0
 	go.opentelemetry.io/otel/sdk v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v0.1.24 h1:jN0CGLYiFy5fQJghqi3frKJVxoMoq+Weqc2PJNRsPAk=
-github.com/unikorn-cloud/core v0.1.24/go.mod h1:cP39UQN7aSmsfjQuSMsworI4oBIwx4oA4u20CbPpfZw=
+github.com/unikorn-cloud/core v0.1.26 h1:Z7GToUJ7foMWuUVpDRr2djuWnvGtTubjDtUeG8kjNmg=
+github.com/unikorn-cloud/core v0.1.26/go.mod h1:cP39UQN7aSmsfjQuSMsworI4oBIwx4oA4u20CbPpfZw=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=

--- a/pkg/providers/interfaces.go
+++ b/pkg/providers/interfaces.go
@@ -32,4 +32,6 @@ type Provider interface {
 	Images(ctx context.Context) (ImageList, error)
 	// ConfigureCluster does any provider specific configuration for a cluster.
 	ConfigureCluster(ctx context.Context, cluster *unikornv1.KubernetesCluster) error
+	// DeconfigureCluster does any provider specific cluster cleanup.
+	DeconfigureCluster(ctx context.Context, annotations map[string]string) error
 }

--- a/pkg/providers/openstack/provider.go
+++ b/pkg/providers/openstack/provider.go
@@ -486,3 +486,8 @@ func (p *Provider) ConfigureCluster(ctx context.Context, cluster *unikornv1.Kube
 
 	return nil
 }
+
+// DeconfigureCluster does any provider specific cluster cleanup.
+func (p *Provider) DeconfigureCluster(ctx context.Context, annotations map[string]string) error {
+	return nil
+}

--- a/pkg/provisioners/managers/cluster/provisioner.go
+++ b/pkg/provisioners/managers/cluster/provisioner.go
@@ -250,7 +250,11 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 
 	// This event is used to trigger cleanup operations in the provider.
 	recorder := manager.FromContext(ctx).GetEventRecorderFor("cluster")
-	recorder.AnnotatedEventf(&p.cluster, providers.GetAnnotations(&p.cluster), "Normal", "ClusterDeleted", "cluster has been deleted successfully")
+
+	annotations := providers.GetAnnotations(&p.cluster)
+	annotations[constants.RegionAnnotation] = p.cluster.Spec.Region
+
+	recorder.AnnotatedEventf(&p.cluster, annotations, "Normal", "ClusterDeleted", "cluster has been deleted successfully")
 
 	return nil
 }

--- a/pkg/server/reaper/reaper.go
+++ b/pkg/server/reaper/reaper.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2024 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reaper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/unikorn-cloud/core/pkg/constants"
+	"github.com/unikorn-cloud/unikorn/pkg/server/handler/region"
+
+	eventsv1 "k8s.io/api/events/v1"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var (
+	ErrInvalidClient = errors.New("client invalid")
+
+	ErrDataMissing    = errors.New("data missing")
+	ErrUnexpectedType = errors.New("unexpected type")
+)
+
+// Seasons don't fear the reaper, nor do wind or the sun or the rain.
+// Peforms asynchronous cleanup tasks.
+type Reaper struct {
+	client client.Client
+}
+
+func New(client client.Client) *Reaper {
+	return &Reaper{
+		client: client,
+	}
+}
+
+func (r *Reaper) Run(ctx context.Context) error {
+	log := log.FromContext(ctx)
+
+	watchingClient, ok := r.client.(client.WithWatch)
+	if !ok {
+		return fmt.Errorf("%w: client does not implement watches", ErrInvalidClient)
+	}
+
+	var events eventsv1.EventList
+
+	watcher, err := watchingClient.Watch(ctx, &events, &client.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	eventStream := watcher.ResultChan()
+
+	// Please note when using Kubernetes watches of events that you may see
+	// some historical events for things in the last hour.
+	go func() {
+		for {
+			event := <-eventStream
+
+			log.V(1).Info("witnessed an event", "event", event)
+
+			if event.Type != watch.Added {
+				continue
+			}
+
+			realEvent, ok := event.Object.(*eventsv1.Event)
+			if !ok {
+				log.Error(ErrUnexpectedType, "unable to decode event")
+			}
+
+			if err := r.handleEvent(ctx, realEvent); err != nil {
+				log.Error(err, "event handling failed")
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (r *Reaper) handleEvent(ctx context.Context, event *eventsv1.Event) error {
+	log := log.FromContext(ctx)
+
+	if event.Reason == "ClusterDeleted" {
+		log.Info("processing cluster deletion event", "event", event)
+
+		regionName, ok := event.Annotations[constants.RegionAnnotation]
+		if !ok {
+			return fmt.Errorf("%w: region annotation not present", ErrDataMissing)
+		}
+
+		provider, err := region.NewClient(r.client).Provider(ctx, regionName)
+		if err != nil {
+			return err
+		}
+
+		return provider.DeconfigureCluster(ctx, event.Annotations)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Ideally, when a cluster is finished with we want to free up resources. At the moment, that's projects, but it'll be a world of hurt if we start leaking VLANs later down the line.  As the provisioners don't know about providers, the logical place is just to wang it in server, which does, and trigger cleanups based on events from the provisioners.