### PR TITLE
Do Reaper Resource Cleanup

### DIFF
--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: v0.2.4
-appVersion: v0.2.4
+version: v0.2.5
+appVersion: v0.2.5
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/unikorn/main/icons/default.png

--- a/pkg/providers/openstack/identity.go
+++ b/pkg/providers/openstack/identity.go
@@ -178,6 +178,15 @@ func (c *IdentityClient) CreateProject(ctx context.Context, domainID, name strin
 	return projects.Create(c.client, opts).Extract()
 }
 
+func (c *IdentityClient) DeleteProject(ctx context.Context, projectID string) error {
+	tracer := otel.GetTracerProvider().Tracer(constants.Application)
+
+	_, span := tracer.Start(ctx, "/identity/v3/auth/projects/"+projectID, trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+
+	return projects.Delete(c.client, projectID).Err
+}
+
 // ListAvailableProjects lists projects that an authenticated (but unscoped) user can
 // scope to.
 func (c *IdentityClient) ListAvailableProjects(ctx context.Context) ([]projects.Project, error) {

--- a/pkg/providers/openstack/provider.go
+++ b/pkg/providers/openstack/provider.go
@@ -489,5 +489,15 @@ func (p *Provider) ConfigureCluster(ctx context.Context, cluster *unikornv1.Kube
 
 // DeconfigureCluster does any provider specific cluster cleanup.
 func (p *Provider) DeconfigureCluster(ctx context.Context, annotations map[string]string) error {
-	return nil
+	projectID, ok := annotations[ProjectIDAnnotation]
+	if !ok {
+		return fmt.Errorf("%w: missing project ID annotation", ErrKeyUndefined)
+	}
+
+	identityService, err := p.identity(ctx)
+	if err != nil {
+		return err
+	}
+
+	return identityService.DeleteProject(ctx, projectID)
 }


### PR DESCRIPTION
Final part of reaping, the cluster controller raises an event, the server picks up the event and uses its provider powers to trigger a cleanup, and that deletes the project, that _should_ cascade down and clean up any other stuff lying about.