### PR TITLE
Fix Image Selection

### DIFF
--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: v0.2.5
-appVersion: v0.2.5
+version: v0.2.6
+appVersion: v0.2.6
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/unikorn/main/icons/default.png

--- a/pkg/server/handler/cluster/conversion.go
+++ b/pkg/server/handler/cluster/conversion.go
@@ -206,7 +206,9 @@ func (c *Client) defaultImage(ctx context.Context, provider providers.Provider, 
 		return nil, err
 	}
 
-	images = slices.DeleteFunc(images, func(x providers.Image) bool { return x.KubernetesVersion == version })
+	images = slices.DeleteFunc(images, func(x providers.Image) bool {
+		return x.KubernetesVersion != version
+	})
 
 	if len(images) == 0 {
 		return nil, errors.OAuth2ServerError("unable to select an image")


### PR DESCRIPTION
For ease of use, the end user should just select a K8S version and we'll do the rest.  Obviously to do that you need to select the correct image based on version, which I utterly failed to do!