### PR TITLE
Fix Token Expiry

### DIFF
--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: v0.2.6
-appVersion: v0.2.6
+version: v0.2.7
+appVersion: v0.2.7
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/unikorn/main/icons/default.png

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.19.0
 	github.com/spdx/tools-golang v0.5.3
 	github.com/spf13/pflag v1.0.5
-	github.com/unikorn-cloud/core v0.1.26
+	github.com/unikorn-cloud/core v0.1.27
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.24.0
 	go.opentelemetry.io/otel/sdk v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v0.1.26 h1:Z7GToUJ7foMWuUVpDRr2djuWnvGtTubjDtUeG8kjNmg=
-github.com/unikorn-cloud/core v0.1.26/go.mod h1:cP39UQN7aSmsfjQuSMsworI4oBIwx4oA4u20CbPpfZw=
+github.com/unikorn-cloud/core v0.1.27 h1:QPksITowofOPcoMT81pr9PqrhritPu2K7XQbZfD43wQ=
+github.com/unikorn-cloud/core v0.1.27/go.mod h1:cP39UQN7aSmsfjQuSMsworI4oBIwx4oA4u20CbPpfZw=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=


### PR DESCRIPTION
The OIDC lib hides the underlying HTTP status code, or makes it stupidy hard to grok, so we were just returning 500.  The UI stuff should get the 403 propagated though so it can refresh the access token.  Bring in a new core library that does this.