### PR TITLE
Remove _member_ Role

### DIFF
--- a/pkg/providers/openstack/provider.go
+++ b/pkg/providers/openstack/provider.go
@@ -353,8 +353,15 @@ func roleNameToID(roles []roles.Role, name string) (string, error) {
 	return "", fmt.Errorf("%w: role %s", ErrResourceNotFound, name)
 }
 
-// TODO: make this configurable, this is just a default.
+// getRequiredRoles returns the roles required for a user to create, manage and delete
+// a cluster.
 func (p *Provider) getRequiredRoles() []string {
+	if p.region.Spec.Openstack.Identity != nil && len(p.region.Spec.Openstack.Identity.ClusterRoles) > 0 {
+		return p.region.Spec.Openstack.Identity.ClusterRoles
+	}
+
+	// TODO: _member_ shouldn't be necessary, delete me when we get a hsndle on it.
+	// This is quired by Octavia to list providers and load balancers at the very least.
 	defaultRoles := []string{
 		"_member_",
 		"member",


### PR DESCRIPTION
This is a legacy thing apparently, and must get covered by either `member` or be implicit.  However, life.  Seems our provider requires it for now, so just use an explicit list if provided to remove a TODO.