### PR TITLE
Enable pprof Server

### DIFF
--- a/charts/unikorn/templates/unikorn-server.yaml
+++ b/charts/unikorn/templates/unikorn-server.yaml
@@ -124,6 +124,8 @@ spec:
           containerPort: 6080
         - name: prometheus
           containerPort: 8080
+        - name: pprof
+          containerPort: 6060
         # Note, this is quite CPU intensive, especially when going wide!
         # TODO: profile me.
         resources:


### PR DESCRIPTION
Not on the main web interface for obvious reason, so you'll need to port-forward through port 6060.  I indend to move the server shiz to be shared anyway, as this is 99% the same as identity, so we'll enable it for all services at that point in time when I can do controllers too.