### PR TITLE
Fix Infinite Reaper Loop

### DIFF
--- a/charts/unikorn/templates/unikorn-server.yaml
+++ b/charts/unikorn/templates/unikorn-server.yaml
@@ -59,7 +59,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - events.k8s.io
+  - ""
   resources:
   - events
   verbs:


### PR DESCRIPTION
Watches are flaky, and I should know this by now!  Seems the channel was closed by something, then it sat in an infinite loop constantly receiving nil.  Fix this so it restarts the watch.  Also add a field selector so that we only get the events we care about.