### PR TITLE
NS-78: Bump helm-charts version + vcluster.

### DIFF
--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -90,7 +90,7 @@ spec:
   tags:
   - infrastructure
   versions:
-  - version: v0.1.11
+  - version: v0.1.12
     repo: https://unikorn-cloud.github.io/helm-cluster-api
     chart: cluster-api
     interface: 1.0.0

--- a/charts/unikorn/templates/clustermanagerapplicationbundles.yaml
+++ b/charts/unikorn/templates/clustermanagerapplicationbundles.yaml
@@ -9,7 +9,7 @@ spec:
     reference:
       kind: HelmApplication
       name: vcluster
-      version: 0.15.7
+      version: 0.19.5
   - name: cert-manager
     reference:
       kind: HelmApplication
@@ -19,4 +19,4 @@ spec:
     reference:
       kind: HelmApplication
       name: cluster-api
-      version: v0.1.11
+      version: v0.1.12


### PR DESCRIPTION
Required: https://github.com/unikorn-cloud/helm-cluster-api/pull/3 to be merged and tagged.